### PR TITLE
Fix block comments.

### DIFF
--- a/__tests__/__snapshots__/proptypes-to-flow-test.js.snap
+++ b/__tests__/__snapshots__/proptypes-to-flow-test.js.snap
@@ -92,6 +92,25 @@ exports[`React.PropTypes to flow does not touch non React classes 1`] = `
     "
 `;
 
+exports[`React.PropTypes to flow handles block comments 1`] = `
+"
+      /* @flow */
+      import React from 'react';
+
+      export type Props = {
+        /**
+         * block comment
+         */
+        optionalArray?: Array<any>,
+        anotherProp?: string,
+      };
+
+      export default class Test extends React.Component {
+        props: Props;
+      }
+    "
+`;
+
 exports[`React.PropTypes to flow handles functional components with expression body 1`] = `
 "
       /* @flow */

--- a/__tests__/proptypes-to-flow-test.js
+++ b/__tests__/proptypes-to-flow-test.js
@@ -445,4 +445,21 @@ describe('React.PropTypes to flow', () => {
     expect(transformString(input)).toMatchSnapshot();
   });
 
+  it('handles block comments', () => {
+    const input = `
+      import React from 'react';
+
+      export default class Test extends React.Component {
+        static propTypes = {
+          /**
+           * block comment
+           */
+          optionalArray: React.PropTypes.array,
+          anotherProp: React.PropTypes.string,
+        };
+      }
+    `;
+
+    expect(transformString(input)).toMatchSnapshot();
+  });
 });

--- a/src/helpers/transformProperties.js
+++ b/src/helpers/transformProperties.js
@@ -3,8 +3,8 @@ import propTypeToFlowType from './propTypeToFlowType';
 export default function transformProperties(j, properties) {
   return properties.map(property => {
     const type = propTypeToFlowType(j, property.key, property.value);
-    type.value.leadingComments = property.leadingComments;
-    type.value.comments = property.comments;
+    type.leadingComments = property.leadingComments;
+    type.comments = property.comments;
     return type;
   });
 }


### PR DESCRIPTION
Fixes #9 by assigning the `leadingComments` and `comments` from the `property` to `type` rather than `type.value`.