### PR TITLE
Prettier + CI

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,9 +1,15 @@
 module.exports = {
-  extends: 'airbnb-base',
+  extends: [
+    'airbnb-base',
+    'prettier',
+  ],
   env: {
     'node': true,
   },
   root: true,
+  plugins: [
+    'prettier',
+  ],
   rules: {
     'comma-dangle': ['error', 'always-multiline'],
     'import/order': ['error', {
@@ -18,6 +24,8 @@ module.exports = {
     'no-param-reassign': 'off',
     'no-console': 'off',
     'no-warning-comments': ['warn', { 'terms': ['fixme'], 'location': 'start' }],
+
+    'prettier/prettier': ['error', {'trailingComma': 'es5', 'singleQuote': true} ],
 
     // NOTE: Disabled to not do too many changes to original codebase:
     'consistent-return': 'off',

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ before_install:
 script:
   - npm prune
   - npm update
+  - npm run check
   - npm run build
-  - npm run test:coverage
   - codecov
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,11 @@ before_install:
   - npm install -g codecov
 
 script:
-  - npm prune
-  - npm update
-  - npm run check
-  - npm run build
+  - yarn run check
+  - yarn run build
   - codecov
 
-cache:
-  directories:
-    - node_modules
+cache: yarn
 
 after_success:
   - bash <(curl -s https://codecov.io/bash) -f coverage/coverage-final.json

--- a/package.json
+++ b/package.json
@@ -5,12 +5,11 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "babel src --out-dir lib",
-    "check": "npm run lint && npm run test:coverage",
+    "check": "npm run lint:bail && npm run test:coverage",
     "prepublishOnly": "npm run check && npm run build",
     "precommit": "lint-staged",
-    "lint": "eslint src __tests__",
-    "pretty": "prettier --trailing-comma es5 --single-quote",
-    "pretty-fix": "npm run pretty -- --write src/**/*.js __tests__/**/*.js",
+    "lint:bail": "eslint src __tests__",
+    "lint": "eslint src __tests__ --fix",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch"
@@ -40,7 +39,9 @@
     "babel-preset-stage-0": "^6.16.0",
     "eslint": "^3.9.1",
     "eslint-config-airbnb-base": "^10.0.1",
+    "eslint-config-prettier": "^2.1.1",
     "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-prettier": "^2.1.2",
     "husky": "^0.13.3",
     "jest": "^19.0.2",
     "jscodeshift": "^0.3.30",
@@ -49,7 +50,7 @@
   },
   "lint-staged": {
     "*.js": [
-      "npm run pretty --write",
+      "eslint --fix",
       "npm run test --bail --findRelatedTests"
     ]
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1575,6 +1575,12 @@ eslint-config-airbnb-base@^10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-10.0.1.tgz#f17d4e52992c1d45d1b7713efbcd5ecd0e7e0506"
 
+eslint-config-prettier@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.1.1.tgz#ab3923fb704eebecab6960906b7d0d6e801cde58"
+  dependencies:
+    get-stdin "^5.0.1"
+
 eslint-import-resolver-node@^0.2.0:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz#5add8106e8c928db2cba232bcd9efa846e3da16c"
@@ -1604,6 +1610,13 @@ eslint-plugin-import@^2.2.0:
     lodash.cond "^4.3.0"
     minimatch "^3.0.3"
     pkg-up "^1.0.0"
+
+eslint-plugin-prettier@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.1.2.tgz#4b90f4ee7f92bfbe2e926017e1ca40eb628965ea"
+  dependencies:
+    fast-diff "^1.1.1"
+    jest-docblock "^20.0.1"
 
 eslint@^3.9.1:
   version "3.19.0"
@@ -1747,6 +1760,10 @@ extglob@^0.3.1:
 extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
+
+fast-diff@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.1.1.tgz#0aea0e4e605b6a2189f0e936d4b7fbaf1b7cfd9b"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -1922,7 +1939,7 @@ get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
 
-get-stdin@5.0.1:
+get-stdin@5.0.1, get-stdin@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
 
@@ -2451,6 +2468,10 @@ jest-diff@^19.0.0:
     diff "^3.0.0"
     jest-matcher-utils "^19.0.0"
     pretty-format "^19.0.0"
+
+jest-docblock@^20.0.1:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.0.3.tgz#17bea984342cc33d83c50fbe1545ea0efaa44712"
 
 jest-environment-jsdom@^19.0.2:
   version "19.0.2"


### PR DESCRIPTION
This PR 
- makes `prettier` run as part of eslint. IMO simplifies the workflow a bit, as there is only one lint target.
- besides we now run linting on CI
- uses yarn instead of npm on travis