### PR TITLE
handle presence of defaultProps

### DIFF
--- a/__tests__/__snapshots__/proptypes-to-flow-test.js.snap
+++ b/__tests__/__snapshots__/proptypes-to-flow-test.js.snap
@@ -147,6 +147,29 @@ exports[`React.PropTypes to flow handles functional components with expression b
     "
 `;
 
+exports[`React.PropTypes to flow handles presence of defaultProps 1`] = `
+"
+      /* @flow */
+      import React from 'react';
+
+      export type Props = {
+        /**
+         * block comment
+         */
+        optionalArray?: Array<any>,
+        anotherProp?: string,
+      };
+
+      export default class Test extends React.Component {
+        props: Props;
+
+        static defaultProps = {
+          anotherProp: ''
+        };
+      }
+    "
+`;
+
 exports[`React.PropTypes to flow preserves comments 1`] = `
 "
       /* @flow */

--- a/__tests__/proptypes-to-flow-test.js
+++ b/__tests__/proptypes-to-flow-test.js
@@ -506,6 +506,30 @@ describe('React.PropTypes to flow', () => {
     expect(transformString(input)).toMatchSnapshot();
   });
 
+  it('handles presence of defaultProps', () => {
+    const input = `
+      import React from 'react';
+
+      export default class Test extends React.Component {
+        static propTypes = {
+          /**
+           * block comment
+           */
+          optionalArray: React.PropTypes.array,
+          anotherProp: React.PropTypes.string,
+        };
+
+        static defaultProps = {
+          anotherProp: ''
+        };
+      }
+    `;
+
+    const output = transformString(input);
+    expect(output).toContain('type Props =');
+    expect(output).toMatchSnapshot();
+  });
+
   it('does not touch files with flow Props already declared', () => {
     const input = `
       /* @flow */

--- a/src/transformers/es6Classes.js
+++ b/src/transformers/es6Classes.js
@@ -16,9 +16,7 @@ const isStaticPropType = p => {
 };
 
 function containsFlowProps(classBody) {
-  return !!classBody.find(bodyElement =>
-    bodyElement.key.name.toLowerCase().includes('props')
-  );
+  return !!classBody.find(bodyElement => bodyElement.key.name === 'props');
 }
 
 /**


### PR DESCRIPTION
Logic assumed that any key case-insensitively containing "props" would indicate the file had a `props:` declaration. This would cause files with `defaultProps:` to be skipped.

This fixes that and includes test case that previously would fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/billyvg/codemod-proptypes-to-flow/21)
<!-- Reviewable:end -->
